### PR TITLE
The chat_id parameter is not defined

### DIFF
--- a/inc/bot.class.php
+++ b/inc/bot.class.php
@@ -68,7 +68,7 @@ class PluginTelegrambotBot {
 	     'SELECT' => 'users.username`,`user.id',
          'FROM' => 'glpi_plugin_telegrambot_users as users',
          'INNER JOIN' => [
-            'glpi_plugin_telegrambot_chat as user' => [
+            'glpi_plugin_telegrambot_user as user' => [
                'FKEY' => [
                   'users' => 'username',
                   'user' => 'username'

--- a/inc/bot.class.php
+++ b/inc/bot.class.php
@@ -65,16 +65,17 @@ class PluginTelegrambotBot {
       $chat_id = null;
 
       $result = $DB->request([
-         'FROM' => 'glpi_plugin_telegrambot_users',
+	     'SELECT' => 'users.username`,`user.id',
+         'FROM' => 'glpi_plugin_telegrambot_users as users',
          'INNER JOIN' => [
-            'glpi_plugin_telegrambot_user' => [
+            'glpi_plugin_telegrambot_chat as user' => [
                'FKEY' => [
-                  'glpi_plugin_telegrambot_users' => 'username',
-                  'glpi_plugin_telegrambot_user' => 'username'
+                  'users' => 'username',
+                  'user' => 'username'
                ]
             ]
          ],
-         'WHERE' => ['glpi_plugin_telegrambot_users.id' => $user_id]
+         'WHERE' => ['users.id' => $user_id]
       ]);
 
       if ($row = $result->next()) {


### PR DESCRIPTION
### Changes description
Messages are not sent because chat_id is not defined in the get Cat ID($user_id) method)
<!-- Describe results, user mentions, screenshots, screencast (gif) -->

### Checklist

Please check if your PR fulfills the following specifications:

- [x] Tests for the changes have been added
- [x] Docs have been added/updated

### References

<!-- issues related (for reference or to be closed) and/or links of discuss -->

Close #N/A